### PR TITLE
Ignore WS_INLINE

### DIFF
--- a/src/global_grammar.lark
+++ b/src/global_grammar.lark
@@ -2,42 +2,41 @@ start: (font_definition | color_definition | type_definition | canvas_definition
 
 identifier: CNAME
 
-_INLINE_WHITESPACE: WS_INLINE
 _WHITESPACE: WS
 _NEWLINE: NEWLINE
 
-color_definition: "define" _INLINE_WHITESPACE "color" _INLINE_WHITESPACE identifier _INLINE_WHITESPACE hex_color _INLINE_WHITESPACE? (_comment? | _NEWLINE)
+color_definition: "define color" identifier hex_color (_comment? | _NEWLINE)
 hex_color: HEX_COLOR
 HEX_COLOR: "#" HEXDIGIT HEXDIGIT HEXDIGIT [HEXDIGIT HEXDIGIT HEXDIGIT]
 
-font_definition: "define" _INLINE_WHITESPACE "font" _INLINE_WHITESPACE identifier _INLINE_WHITESPACE font_name _INLINE_WHITESPACE font_size [_INLINE_WHITESPACE font_weight] _INLINE_WHITESPACE? (_comment? | _NEWLINE)
+font_definition: "define font" identifier font_name font_size [font_weight] (_comment? | _NEWLINE)
 font_name: ESCAPED_STRING
 font_size: INT
 FONT_WEIGHT: "thin" | "regular" | "bold"
 font_weight: FONT_WEIGHT
 
-type_definition: "define" _INLINE_WHITESPACE identifier [_INLINE_WHITESPACE int_width _INLINE_WHITESPACE int_height] _item_body
+type_definition: "define" identifier [int_width int_height] _item_body
 int_width: INT
 int_height: INT
-_item_body: _INLINE_WHITESPACE? "{" _WHITESPACE? item_list _WHITESPACE? "}" _NEWLINE? _WHITESPACE?
+_item_body: "{" _WHITESPACE? item_list _WHITESPACE? "}" _NEWLINE? _WHITESPACE?
 item_list: (item _NEWLINE _WHITESPACE?)* [item _WHITESPACE?]
 
 file_name: ESCAPED_STRING
 
-canvas_definition: "canvas" _INLINE_WHITESPACE file_name _INLINE_WHITESPACE size _item_body
+canvas_definition: "canvas" file_name size _item_body
 
 item: rect | circle | ellipse | line | polygon | text | image | custom
 
 color: identifier | hex_color
 
-modifier_list: (modifier _INLINE_WHITESPACE)*
+modifier_list: modifier*
 modifier: STATIC_MODIFIER | outlined | rotated
 STATIC_MODIFIER: "left"
     | "right"
     | "center"
     | "clipped"
-outlined: "outlined" _INLINE_WHITESPACE color _INLINE_WHITESPACE thickness [_INLINE_WHITESPACE opacity]
-rotated: "rotated" _INLINE_WHITESPACE angle
+outlined: "outlined" color thickness [opacity]
+rotated: "rotated" angle
 
 ?sum: product
     | sum "+" product         -> add
@@ -56,7 +55,7 @@ unit: UNIT -> unit
 UNIT: "h" | "w"
 
 expression: atom
-_expr_tuple: expression _INLINE_WHITESPACE expression
+_expr_tuple: expression expression
 position: _expr_tuple
 size: _expr_tuple
 thickness: INT
@@ -66,14 +65,14 @@ font: CNAME
 content: ESCAPED_STRING
 path: ESCAPED_STRING
 
-rect: modifier_list "rect" _INLINE_WHITESPACE position _INLINE_WHITESPACE size [_INLINE_WHITESPACE color] [_item_body]
-circle: modifier_list "circle" _INLINE_WHITESPACE position _INLINE_WHITESPACE expression [_INLINE_WHITESPACE color] [_item_body]
-ellipse: modifier_list "ellipse" _INLINE_WHITESPACE position _INLINE_WHITESPACE expression _INLINE_WHITESPACE expression [_INLINE_WHITESPACE color] [_item_body]
-line: "line" _INLINE_WHITESPACE position _INLINE_WHITESPACE position [_INLINE_WHITESPACE color] [_INLINE_WHITESPACE thickness]
-polygon: modifier_list "polygon" _INLINE_WHITESPACE position _INLINE_WHITESPACE position (_INLINE_WHITESPACE position)* [_INLINE_WHITESPACE color] [_item_body]
-text: modifier_list "text" _INLINE_WHITESPACE position _INLINE_WHITESPACE font _INLINE_WHITESPACE color [_INLINE_WHITESPACE expression] _INLINE_WHITESPACE content
-image: modifier_list "image" _INLINE_WHITESPACE position _INLINE_WHITESPACE expression [_INLINE_WHITESPACE expression] _INLINE_WHITESPACE path
-custom: identifier _INLINE_WHITESPACE position [_INLINE_WHITESPACE size]
+rect: modifier_list "rect" position size [color] [_item_body]
+circle: modifier_list "circle" position expression [color] [_item_body]
+ellipse: modifier_list "ellipse" position expression expression [color] [_item_body]
+line: "line" position position [color] [thickness]
+polygon: modifier_list "polygon" position position+ [color] [_item_body]
+text: modifier_list "text" position font color [expression] content
+image: modifier_list "image" position expression [expression] path
+custom: identifier position [size]
 
 _comment: _NEWLINE? (_INLINE_COMMENT | _MULTILINE_COMMENT) _NEWLINE?
 
@@ -87,3 +86,5 @@ _comment: _NEWLINE? (_INLINE_COMMENT | _MULTILINE_COMMENT) _NEWLINE?
 %import common.HEXDIGIT
 %import common.C_COMMENT -> _MULTILINE_COMMENT
 %import common.CPP_COMMENT -> _INLINE_COMMENT
+
+%ignore WS_INLINE


### PR DESCRIPTION
@JoeFurfaro It seems to work. I think we should use this as it simplifies the lark code and makes it much more flexible in terms of allowing whitespace.